### PR TITLE
Fix rolling update timeout failure

### DIFF
--- a/wso2am/apim/cf.yaml
+++ b/wso2am/apim/cf.yaml
@@ -1099,7 +1099,7 @@ Mappings:
     us-east-2:
       Ubuntu1804: ami-025381ad18973cd94
     us-west-1:
-      Ubuntu1804: ami-098eda006170f2afb
+      Ubuntu1804: ami-0d7d4852f5939bc5e
     us-west-2:
       Ubuntu1804: ami-06b2d90e2e762a752
     ap-south-1:

--- a/wso2am/apim/cf.yaml
+++ b/wso2am/apim/cf.yaml
@@ -559,7 +559,7 @@ Resources:
       AutoScalingRollingUpdate:
         MaxBatchSize: '2'
         MinInstancesInService: '1'
-        PauseTime: PT10M
+        PauseTime: PT30M
         SuspendProcesses:
           - AlarmNotification
         WaitOnResourceSignals: true
@@ -693,7 +693,7 @@ Resources:
       AutoScalingRollingUpdate:
         MaxBatchSize: '2'
         MinInstancesInService: '1'
-        PauseTime: PT20M
+        PauseTime: PT30M
         SuspendProcesses:
           - AlarmNotification
         WaitOnResourceSignals: true

--- a/wso2ei/ei_integrator/cf.yaml
+++ b/wso2ei/ei_integrator/cf.yaml
@@ -1034,7 +1034,7 @@ Mappings:
     us-east-2:
       Ubuntu1804: ami-025381ad18973cd94
     us-west-1:
-      Ubuntu1804: ami-098eda006170f2afb
+      Ubuntu1804: ami-0d7d4852f5939bc5e
     us-west-2:
       Ubuntu1804: ami-06b2d90e2e762a752
     ap-south-1:

--- a/wso2ei/ei_integrator/cf.yaml
+++ b/wso2ei/ei_integrator/cf.yaml
@@ -516,7 +516,7 @@ Resources:
       AutoScalingRollingUpdate:
         MaxBatchSize: '2'
         MinInstancesInService: '1'
-        PauseTime: PT10M
+        PauseTime: PT20M
         SuspendProcesses:
           - AlarmNotification
         WaitOnResourceSignals: true

--- a/wso2is/is/cf.yaml
+++ b/wso2is/is/cf.yaml
@@ -1033,7 +1033,7 @@ Mappings:
     us-east-2:
       Ubuntu1804: ami-025381ad18973cd94
     us-west-1:
-      Ubuntu1804: ami-098eda006170f2afb
+      Ubuntu1804: ami-0d7d4852f5939bc5e
     us-west-2:
       Ubuntu1804: ami-06b2d90e2e762a752
     ap-south-1:

--- a/wso2is/is/cf.yaml
+++ b/wso2is/is/cf.yaml
@@ -516,7 +516,7 @@ Resources:
       AutoScalingRollingUpdate:
         MaxBatchSize: '2'
         MinInstancesInService: '1'
-        PauseTime: PT10M
+        PauseTime: PT20M
         SuspendProcesses:
           - AlarmNotification
         WaitOnResourceSignals: true


### PR DESCRIPTION
## Purpose
> Fix rolling update failure 
> Fix "Monitoring AMI cannot be found in us-west-1"

## Goals
> Increase the cfn signal timeout for rolling update
> Add a new Monitoring master AMI for missing AMI in us-west-1